### PR TITLE
small collection of my docker-compose files

### DIFF
--- a/adguardhome/docker-compose.yml
+++ b/adguardhome/docker-compose.yml
@@ -1,0 +1,44 @@
+version: "3.7"
+
+services:
+  adguardhome:
+    image: adguard/adguardhome
+    container_name: adguardhome
+    # For DHCP it is recommended to remove these ports and instead add: network_mode: "host"
+    restart: always
+    ports:
+      # DNS Ports
+      - "53:53/tcp"
+      - "53:53/udp"
+      # DNS over HTTPs
+      #- "443:443/tcp"
+      # DNS over TLS
+      #- "853:853/tcp"
+      # DNS over QUIC
+      #- "784:784/udp"
+      # DNS Crypt
+      #- "5443:5443/tcp"
+      #- "5443:5443/udp"
+      # DHCP Ports
+      #- "67:67/udp"
+      #- "68:68/tcp"
+      #- "68:68/udp"
+      # Dashboard
+      - "3000:3000/tcp"
+      - "8080:80/tcp"
+    environment:
+      TZ: Europe/Berlin
+    volumes:
+      - "/volume1/docker/adguardhome/workdir:/opt/adguardhome/work"
+      - "/volume1/docker/adguardhome/confdir:/opt/adguardhome/conf"
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
+    networks:
+      - app-nw
+
+networks:
+  app-nw:
+    internal: false
+    driver: bridge
+    driver_opts:
+      com.docker.network.bridge.name: br-adguard

--- a/endlessh-go/docker-compose.yml
+++ b/endlessh-go/docker-compose.yml
@@ -1,0 +1,60 @@
+version: '3.5'
+services:
+
+  endlessh:
+    container_name: endlessh
+    image: shizunge/endlessh-go:latest
+    restart: always
+    command:
+      - -interval_ms=1000
+      - -logtostderr
+      - -v=1
+      - -enable_prometheus
+      - -geoip_supplier=ip-api
+    networks:
+      - example_network
+    ports:
+      - 2222:2222 # SSH port
+      - 127.0.0.1:2112:2112 # Prometheus metrics port
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    restart: always
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=45d
+      - --web.console.libraries=/usr/share/prometheus/console_libraries
+      - --web.console.templates=/usr/share/prometheus/consoles
+      - --web.enable-admin-api
+    networks:
+      - example_network
+    ports:
+      - 127.0.0.1:9090:9090
+    volumes:
+      - /volume1/docker/endlessh-go/prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus:/prometheus
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    restart: always
+    networks:
+      - example_network
+    ports:
+      - 127.0.0.1:3000:3000
+    environment:
+      - GF_SECURITY_ADMIN_USER=examples
+      - GF_SECURITY_ADMIN_PASSWORD=examples
+    volumes:
+      - grafana_var:/var/lib/grafana/
+      - ./grafana-datasource.yml:/etc/grafana/provisioning/datasources/prometheus.yml
+
+networks:
+  example_network:
+
+
+volumes:
+  prometheus:
+  grafana_var:

--- a/h5ai/docker-compose.yml
+++ b/h5ai/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.5'
+services:
+  h5ai:
+    image: awesometic/h5ai:latest
+    container_name: h5ai
+    restart: always
+    environment:
+      - PUID=$UID
+      - PGID=$GID
+      - TZ=Europe/Berlin
+    ports:
+      - "8080:80"
+    volumes:
+      - /volume1/docker/h5ai/shared/dir:/h5ai
+      - /volume1/docker/h5ai/config/dir:/config

--- a/kasm/docker-compose.yml
+++ b/kasm/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "2.1"
+services:
+  kasm:
+    image: lscr.io/linuxserver/kasm:latest
+    container_name: kasm
+    privileged: true
+    environment:
+      - KASM_PORT=443
+      #- DOCKER_HUB_USERNAME=USER #optional
+      #- DOCKER_HUB_PASSWORD=PASS #optional
+    volumes:
+      - /volume1/docker/kasm/data:/opt
+      - /volume1/docker/kasm/profiles:/profiles #optional
+      - /dev/input:/dev/input #optional
+      - /run/udev/data:/run/udev/data #optional
+    ports:
+      - 3000:3000
+      - 8443:443
+    restart: unless-stopped

--- a/nginxproxymanager/docker-compose.yml
+++ b/nginxproxymanager/docker-compose.yml
@@ -1,0 +1,37 @@
+version: '3.8'
+services:
+  app:
+    image: 'jc21/nginx-proxy-manager:latest'
+    restart: unless-stopped
+    ports:
+      # These ports are in format <host-port>:<container-port>
+      - '80:80' # Public HTTP Port
+      - '443:443' # Public HTTPS Port
+      - '8081:81' # Admin Web Port
+      # Add any other Stream port you want to expose
+      # - '21:21' # FTP
+    environment:
+      # Mysql/Maria connection parameters:
+      DB_MYSQL_HOST: "db"
+      DB_MYSQL_PORT: 3306
+      DB_MYSQL_USER: "npm"
+      DB_MYSQL_PASSWORD: "npm"
+      DB_MYSQL_NAME: "npm"
+      # Uncomment this if IPv6 is not enabled on your host
+      # DISABLE_IPV6: 'true'
+    volumes:
+      - /volume1/docker/nginx-proxy-manager/data:/data
+      - /volume1/docker/nginx-proxy-manager/letsencrypt:/etc/letsencrypt
+    depends_on:
+      - db
+
+  db:
+    image: 'jc21/mariadb-aria:latest'
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: 'npm'
+      MYSQL_DATABASE: 'npm'
+      MYSQL_USER: 'npm'
+      MYSQL_PASSWORD: 'npm'
+    volumes:
+      - /volume1/docker/nginx-proxy-manager/mysql:/var/lib/mysql

--- a/owncloud/docker-compose.yml
+++ b/owncloud/docker-compose.yml
@@ -1,0 +1,50 @@
+version: "2.1"
+services:
+  mariadb:
+    image: linuxserver/mariadb:latest
+    #container_name: mariadb
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - MYSQL_ROOT_PASSWORD=bitnami
+      - TZ=Europe/Berlin
+      - MYSQL_DATABASE=db-owncloud #optional
+      - MYSQL_USER=db-owncloud #optional
+      - MYSQL_PASSWORD=db-owncloud1234 #optional
+      #- REMOTE_SQL=http://URL1/your.sql,https://URL2/your.sql #optional
+    volumes:
+      - /volume1/docker/owncloud/mariadb/config:/config
+    #ports:
+    #  - 3306:3306
+    restart: always
+  owncloud:
+    image: owncloud/server:latest
+    #container_name: owncloud_server
+    restart: always
+    ports:
+      - 8080:8080
+      - 8443:8443
+    depends_on:
+      - mariadb
+      #- redis
+    environment:
+      - OWNCLOUD_DOMAIN=localhost
+      - OWNCLOUD_DB_TYPE=mysql
+      - OWNCLOUD_DB_NAME=db-owncloud
+      - OWNCLOUD_DB_USERNAME=db-owncloud
+      - OWNCLOUD_DB_PASSWORD=db-owncloud1234
+      - OWNCLOUD_DB_HOST=mariadb
+      - OWNCLOUD_ADMIN_USERNAME=admin
+      - OWNCLOUD_ADMIN_PASSWORD=admin
+      - OWNCLOUD_MYSQL_UTF8MB4=true
+      #- OWNCLOUD_REDIS_ENABLED=true
+      #- OWNCLOUD_REDIS_HOST=redis
+    #healthcheck:
+    #  test: ["CMD", "/usr/bin/healthcheck"]
+    #  interval: 30s
+    #  timeout: 10s
+    #  retries: 5
+    volumes:
+      - /volume1/docker/owncloud/data:/mnt/data
+
+

--- a/phpmyadmin/docker-compose.yml
+++ b/phpmyadmin/docker-compose.yml
@@ -1,0 +1,39 @@
+version: "2.1"
+services:
+  mariadb:
+    image: linuxserver/mariadb:latest
+    #container_name: mariadb
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - MYSQL_ROOT_PASSWORD=bitnami
+      - TZ=Europe/Berlin
+      #- MYSQL_DATABASE=USER_DB_NAME #optional
+      #- MYSQL_USER=MYSQL_USER #optional
+      #- MYSQL_PASSWORD=DATABASE_PASSWORD #optional
+      #- REMOTE_SQL=http://URL1/your.sql,https://URL2/your.sql #optional
+    volumes:
+      - /volume1/docker/phpmyadmin/mariadb/config:/config
+    ports:
+      - 3306:3306
+    restart: always
+  phpmyadmin:
+    image: linuxserver/phpmyadmin:latest
+    #container_name: phpmyadmin
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Europe/Berlin
+      - PMA_ARBITRARY=0 #optional
+      - PMA_HOST=mariadb
+      #- PMA_ABSOLUTE_URI=https://phpmyadmin.example.com #optional
+    volumes:
+      - /volume1/docker/phpmyadmin/phpmyadmin/config:/config
+    ports:
+      - 8080:80
+      - 8443:443
+    restart: always
+    depends_on:
+      - mariadb
+
+

--- a/pihole-unbound/docker-compose.yml
+++ b/pihole-unbound/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3.0'
+
+volumes:
+  etc_pihole-unbound:
+  etc_pihole_dnsmasq-unbound:
+
+services:
+  pihole:
+    container_name: pihole
+    image: pluim003/pihole-unbound:latest
+    hostname: pihole
+    domainname: pihole.local
+    ports:
+      - 443:443/tcp
+      - 53:53/tcp
+      - 53:53/udp
+      - 8080:80/tcp #Allows use of different port to access pihole web interface when other docker containers use port 80
+      # - 5335:5335/tcp # Uncomment to enable unbound access on local server
+      # - 22/tcp # Uncomment to enable SSH
+    environment:
+      - FTLCONF_LOCAL_IPV4=192.168.178.15
+      - TZ=Europe/Berlin
+      - WEBPASSWORD=YOURPASSWORD
+      - WEBTHEME=default-light
+      - REV_SERVER=true
+      - REV_SERVER_TARGET=192.168.178.1
+      - REV_SERVER_DOMAIN=local
+      - REV_SERVER_CIDR=192.168.0.0/16
+      - PIHOLE_DNS_=127.0.0.1#5335
+      - DNSSEC="true"
+      - DNSMASQ_LISTENING=single
+    volumes:
+      - etc_pihole-unbound:/etc/pihole:rw
+      - etc_pihole_dnsmasq-unbound:/etc/dnsmasq.d:rw
+    restart: unless-stopped

--- a/pihole/docker-compose.yml
+++ b/pihole/docker-compose.yml
@@ -1,0 +1,45 @@
+version: "3.7"
+
+# https://github.com/pi-hole/docker-pi-hole/blob/master/README.md
+
+services:
+  pihole:
+    image: pihole/pihole:latest
+    container_name: pihole
+    # For DHCP it is recommended to remove these ports and instead add: network_mode: "host"
+    restart: always
+    ports:
+      - "53:53/tcp"
+      - "53:53/udp"
+      # DHCP Server Usage
+      #- "67:67/udp"
+      - "8080:80/tcp"
+      - "8443:443/tcp"
+    environment:
+      TZ: Europe/Berlin
+      WEBPASSWORD: YOURPASSWORD
+      DNS1: 1.1.1.1
+      DNS2: 8.8.8.8
+    # Volumes store your data between container upgrades
+    volumes:
+      - /volume1/docker/pihole/data/pihole/conf/:/etc/pihole/
+      - /volume1/docker/pihole/data/dnsmasq.d/conf/:/etc/dnsmasq.d/
+      # run `touch ./var-log/pihole.log` first unless you like errors
+      # - './var-log/pihole.log:/var/log/pihole.log'
+    dns:
+      - 127.0.0.1
+    labels:
+        com.centurylinklabs.watchtower.enable: "true"
+    # Recommended but not required (DHCP needs NET_ADMIN)
+    #   https://github.com/pi-hole/docker-pi-hole#note-on-capabilities
+    #cap_add:
+    #  - NET_ADMIN
+    networks:
+      - app-nw
+
+networks:
+  app-nw:
+    internal: false
+    driver: bridge
+    driver_opts:
+      com.docker.network.bridge.name: br-pihole

--- a/portainer/docker-compose.yml
+++ b/portainer/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  portainer:
+    image: portainer/portainer-ce:latest
+    ports:
+      - 9443:9443
+    volumes:
+        - data:/data
+        - /var/run/docker.sock:/var/run/docker.sock
+    restart: unless-stopped
+volumes:
+  data:

--- a/pyload-ng/docker-compose.yml
+++ b/pyload-ng/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "2.1"
+services:
+  pyload-ng:
+    image: lscr.io/linuxserver/pyload-ng:latest
+    container_name: pyload-ng
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Europe/Berlin
+    volumes:
+      - /volume1/docker/pyload/config:/config
+      - /volume1/docker/pyload/downloads:/downloads
+    ports:
+      - 8000:8000
+      - 9666:9666 #optional
+    restart: unless-stopped

--- a/rust-server/docker-compose.yml
+++ b/rust-server/docker-compose.yml
@@ -1,0 +1,65 @@
+version: '3.5'
+
+services:
+  rust-server:
+    image: didstopia/rust-server:latest
+    container_name: rust-server
+    ports:
+      - '8080:8080'
+      - '28016:28016'
+      - '28015:28015'
+      - '28015:28015/udp'
+    volumes:
+      - './rust_data:/steamcmd/rust'
+    restart: always
+#    environment:
+      ## DEFAULT: "-batchmode -load -nographics +server.secure 1")
+#      - RUST_SERVER_STARTUP_ARGUMENTS=
+      ## DEFAULT: "docker" - Mainly used for the name of the save directory)
+#      - RUST_SERVER_IDENTITY=
+      ## DEFAULT: "" - - RUST server port 28015 if left blank or numeric value)
+#      - RUST_SERVER_PORT=
+      ## DEFAULT: "12345" - The server map seed, must be an integer)
+#      - RUST_SERVER_SEED=
+      ## DEFAULT: "3500" - The map size, must be an integer)
+#      - RUST_SERVER_WORLDSIZE=
+      ## DEFAULT: "- RUST Server [DOCKER]" - The publicly visible server name)
+#      - RUST_SERVER_NAME=
+      ## DEFAULT: "500" - Maximum players on the server, must be an integer)
+#      - RUST_SERVER_MAXPLAYERS=
+      ## DEFAULT: "This is a - RUST server running inside a Docker container!" - The publicly visible server description)
+#      - RUST_SERVER_DESCRIPTION=
+      ## DEFAULT: "https://hub.docker.com/r/didstopia/- RUST-server/" - The publicly visible server website)
+#      - RUST_SERVER_URL=
+      ## DEFAULT: "" - The publicly visible server banner image URL)
+#      - RUST_SERVER_BANNER_URL=
+      ## DEFAULT: "600" - Amount of seconds between automatic saves.)
+#      - RUST_SERVER_SAVE_INTERVAL=
+      ## DEFAULT "1" - Set to 1 or 0 to enable or disable the web-based RCON server)
+#      - RUST_RCON_WEB=
+      ## DEFAULT: "28016" - RCON server port)
+#      - RUST_RCON_PORT=
+      ## DEFAULT: "docker" - RCON server password, please change this!)
+#      - RUST_RCON_PASSWORD=
+      ## DEFAULT: "28082" - - RUST+ companion app port)
+#      - RUST_APP_PORT=
+      ## DEFAULT: Not set - Sets the branch argument to use, eg. set to "-beta prerelease" for the prerelease branch)
+#      - RUST_BRANCH=
+      ## DEFAULT: "0" - Set to 1 to enable fully automatic update checking, notifying players and restarting to install updates)
+#      - RUST_UPDATE_CHECKING=
+      ## DEFAULT: "public" - Set to match the branch that you want to use for updating, ie. "prerelease" or "public", but do not specify arguments like "-beta")
+#      - RUST_UPDATE_BRANCH=
+      ## DEFAULT: "0" - Determines if the server should update and then start (0), only update (1) or only start (2))
+#      - RUST_START_MODE=
+      ## DEFAULT: "0" - Set to 1 to automatically install the latest version of Oxide)
+#      - RUST_OXIDE_ENABLED=
+      ## DEFAULT: "1" - Set to 0 to disable automatic update of Oxide on boot)
+#      - RUST_OXIDE_UPDATE_ON_BOOT=
+      ## DEFAULT: "0" - Set to 1 to enable secure websocket connections to the RCON web interface)
+#      - RUST_RCON_SECURE_WEBSOCKET=
+      ## DEFAULT: "0" - Set to 1 to enable the heartbeat service which will forcibly quit the server if it becomes unresponsive to queries)
+#      - RUST_HEARTBEAT=
+
+
+
+

--- a/rustdesk/docker-compose.yml
+++ b/rustdesk/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3'
+
+networks:
+  rustdesk-net:
+    external: false
+
+services:
+  hbbs:
+    container_name: hbbs
+    ports:
+      - 21115:21115
+      - 21116:21116
+      - 21116:21116/udp
+      - 21118:21118
+    image: rustdesk/rustdesk-server:latest
+    command: hbbs -r 127.0.0.1:21117
+    volumes:
+      - /volume1/docker/rustdesk/data:/root
+    networks:
+      - rustdesk-net
+    depends_on:
+      - hbbr
+    restart: unless-stopped
+
+  hbbr:
+    container_name: hbbr
+    ports:
+      - 21117:21117
+      - 21119:21119
+    image: rustdesk/rustdesk-server:latest
+    command: hbbr
+    volumes:
+      - /volume1/docker/rustdesk/data:/root
+    networks:
+      - rustdesk-net
+    restart: unless-stopped

--- a/ubuntu-xrdp/docker-compose.yml
+++ b/ubuntu-xrdp/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.5'
+services:
+  terminalserver:
+    #build: ./
+    image: danielguerra/ubuntu-xrdp:20.04
+    container_name: uxrdp
+    hostname: terminalserver
+    restart: always
+    shm_size: 4g
+    environment:
+       IDLETIME: 11
+    ports:
+      - "3389:3389"
+      - "2222:22"
+    volumes:
+      - /volume1/docker/ubuntu-xrdp/ssh:/etc/ssh/
+      - /volume1/docker/ubuntu-xrdp/home/:/home/
+

--- a/watchtower/docker-compose.yml
+++ b/watchtower/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3"
+services:
+  watchtower:
+    image: containrrr/watchtower
+    container_name: watchtower
+    restart: always
+    environment:
+      WATCHTOWER_SCHEDULE: "0 0 6 * * *"
+      TZ: Europe/Berlin
+      WATCHTOWER_CLEANUP: "true"
+      WATCHTOWER_DEBUG: "true"
+      #WATCHTOWER_NOTIFICATIONS: "email"
+      #WATCHTOWER_NOTIFICATION_EMAIL_FROM: "cldocker01@cloud.local"
+      #WATCHTOWER_NOTIFICATION_EMAIL_TO: "pushover@mailrise.xyz"
+      ## you have to use a network alias here, if you use your own certificate
+      #WATCHTOWER_NOTIFICATION_EMAIL_SERVER: "10.1.149.19"
+      #WATCHTOWER_NOTIFICATION_EMAIL_SERVER_PORT: "8025"
+      #WATCHTOWER_NOTIFICATION_EMAIL_DELAY: 2
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/wordpress/docker-compose.yml
+++ b/wordpress/docker-compose.yml
@@ -1,0 +1,36 @@
+version: "2.1"
+services:
+  mariadb:
+    image: linuxserver/mariadb:latest
+    #container_name: mariadb
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - MYSQL_ROOT_PASSWORD=bitnami
+      - TZ=Europe/Berlin
+      - MYSQL_DATABASE=wp-wordpress #optional
+      - MYSQL_USER=wp-wordpress #optional
+      - MYSQL_PASSWORD=wp-wordpress1234 #optional
+      #- REMOTE_SQL=http://URL1/your.sql,https://URL2/your.sql #optional
+    volumes:
+      - /volume1/docker/wordpress/mariadb/config:/config
+    #ports:
+    #  - 3306:3306
+    restart: always
+  wordpress:
+    image: wordpress
+    restart: always
+    ports:
+      - 8080:80
+      - 8443:443
+    environment:
+      WORDPRESS_DB_HOST: mariadb
+      WORDPRESS_DB_USER: wp-wordpress
+      WORDPRESS_DB_PASSWORD: wp-wordpress1234
+      WORDPRESS_DB_NAME: wp-wordpress
+    volumes:
+      - /volume1/docker/wordpress/data:/var/www/html
+    depends_on:
+      - mariadb
+
+


### PR DESCRIPTION
### I have some docker-compose files myself that I have either tested on my own or even have in operation somewhere and I would like to make them available here.

You are welcome ( @RPiList ) to adapt the docker-compose files as well as the directories and their names as you wish.

The docker-compose files have been successfully tested at the respective time as I submit them here as pr. (success not guaranteed)

And the files are at least adjusted so that `/volume1/docker/` is used as the directory (where possible) and the standard port for http(s) is not specified.

-----

### the collection includes the following docker-compose files for:
- adguardhome
- endlessh-go
- h5ai
- kasm
- nginxproxymanager
- owncloud
- phpmyadmin
- pihole
- pihole-unbound
- portainer
- pyload-ng
- rust-server
- rustdesk
- ubuntu-xrdp
- watchtower
- wordpress
