### PR TITLE
Update pihole6 docker-compose.yml

### DIFF
--- a/Pihole6/docker-compose.yml
+++ b/Pihole6/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - "1122:80/tcp"
     environment:
       TZ: 'Europe/Berlin'
+      SKIPGRAVITYONBOOT: 'true'
       # WEBPASSWORD: 'set a secure password here or it will be random'
     # Volumes store your data between container upgrades
     volumes:


### PR DESCRIPTION
This adds the environment `SKIPGRAVITYONBOOT: 'true'` so that the pihole container does not update the lists when the container is restarted because otherwise the web interface and pihole as dns server will not be accessible for the entire time until it has synchronized the lists after the container restart. (the automatic weekly list update processes should remain unaffected)