### PR TITLE
fix(wg-easy): change `password` environment to `password_hash`

### DIFF
--- a/Docker-Wireguard/docker-compose.yml
+++ b/Docker-Wireguard/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - WG_HOST=<IP_HIER_EINTRAGEN_ODER_DOMAIN>
 
       # Optional:
-      # - PASSWORD=foobar123
+      # - PASSWORD_HASH=$$2y$$10$$hBCoykrB95WSzuV4fafBzOHWKu9sbyVa34GJr8VV5R/pIelfEMYyG (needs double $$, hash of 'foobar123'; see "https://github.com/wg-easy/wg-easy/blob/master/How_to_generate_an_bcrypt_hash.md" for generate the hash)
       # - WG_PORT=51844
       # - WG_DEFAULT_ADDRESS=10.8.0.x
       - WG_DEFAULT_DNS=1.1.1.1


### PR DESCRIPTION
Since wg-easy version 14, the environment `password` marked as deprecated has been removed and replaced by the environment `password_hash`. This means that if you update the wg-easy container to version 14 or to the latest version, the wg-easy container suddenly appears without a defined password or with the default password "foobar123". To do this, the password must now be set as a hash in the environment `password_hash` and this must be done according to the [instructions](https://github.com/wg-easy/wg-easy/blob/master/How_to_generate_an_bcrypt_hash.md) of the developer of wg-easy.